### PR TITLE
Add Travis-CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+script:
+  - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
+jdk:
+  - oraclejdk8
 script:
   - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ jdk:
   - oraclejdk8
 script:
   - jdk_switcher use oraclejdk8
+  - ./gradlew testRobot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-2017 Robot Skeleton
+2017 Robot Skeleton [![Build Status](https://travis-ci.org/frjalex/Skeleton-2017.svg?branch=master)](https://travis-ci.org/frjalex/Skeleton-2017)
 ---------------------
 This repository contains the skeleton gradle project for 2017, and possibly future years.
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,3 +39,16 @@ jar {
         )
     }
 }
+task test << {
+    println "Executing tests."
+    
+jar {
+    manifest {
+        attributes(
+                'Class-Path': configurations.compile.collect { it.getName() }.join(' '),
+                'Main-Class': testClass,
+                'Robot-Class': testClass
+        )
+    }
+}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'checkstyle'
 
 sourceCompatibility = 1.8
 def robotClass = 'org.usfirst.frc.team4373.Robot'
+def testClass = 'com.example.tests.TestingMain'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ jar {
         )
     }
 }
-task test << {
+task testRobot << {
     println "Executing tests."
     
 jar {

--- a/src/tests/com/example/tests/TestingMain.java
+++ b/src/tests/com/example/tests/TestingMain.java
@@ -1,0 +1,8 @@
+package com.example.tests;
+
+class TestingMain {
+    
+    public static void main(int argc, String[] argv) {
+      // test codes here...
+    }
+}

--- a/src/tests/com/example/tests/TestsLibrary.java
+++ b/src/tests/com/example/tests/TestsLibrary.java
@@ -1,0 +1,10 @@
+package com.example.tests;
+
+class TestsLibrary {
+
+  public TestsLibrary() {
+  
+  }
+  
+  // useful codes here...
+}


### PR DESCRIPTION
This pull request adds Travis CI build support to the project.

A few points to note:
1. As you might have noticed in https://github.com/Roobotics-FRC/Skeleton-2017/commit/d150de75e80db75264bd69b5aba1a00dcc0f9a93 I added a Travis build badge. This badge is for my Travis build, which you'll need to swap it out with yours after merging.
2. Speaking of Travis ownership, you can add your own Travis build instance at travis-ci.org which I don't even need to mention. You can either do that your self or pull me in as a member of the org and make me do it
3. From commits https://github.com/Roobotics-FRC/Skeleton-2017/commit/fccbb2269e410a49acbe070a4eedf7884bc7e9d2 to https://github.com/Roobotics-FRC/Skeleton-2017/commit/2a414859cd344e8f39171921741aec2c24321ed5 I added support for running test codes after the main codes compiled. The testcode package is located under `src/com/example/tests`. Currently I think gradle is only configured to build the codes instead of running them actually. I didn't have time to write the actual run part yet. I think that writing some assert statements that tests out the types and even the values of some important stuffs might be important, so I added this portion. 
   1. `build.gradle` is modified to add a section for `testRobot` (see 3). The travis build file is written accordingly so that at last Travis runs `./gradlew testRobot` after `./gradlew assemble`.

Another thing to state is that Travis by default uses JDK 1.7, which we would need to force it to use 1.8 in the Travis config file. You can also check my Travis build log for more info: https://travis-ci.org/frjalex/Skeleton-2017
